### PR TITLE
Compile changes to allow use of other yosys and nextpnr platform tool…

### DIFF
--- a/fpga/Make.rules
+++ b/fpga/Make.rules
@@ -61,13 +61,18 @@ $(DOXY_DIRS):
 ###################################################################
 
 COMPILE.v	?= yosys
+COMPILE_OPT	?=
+SYNTH 	 	?= synth_ice40
 NEXTPNR 	?= nextpnr-ice40
+NEXTPNR_OPT	?=
+NEXTPNR_FMT	?= asc
 ARACHNE		?= arachne-pnr
-
+PACK		?= icepack
 
 DEVICE		?= up5k
 PACKAGE		?= sg48
 FLASH_PROG	?= sudo iceprog -d i:0x0403:0x6014
+PIN_FMT		?= pcf
 PINMAP		?= pinmap-upduino.pcf
 FREQ		?= 25
 
@@ -77,16 +82,16 @@ FREQ		?= 25
 
 # useful for single-file builds
 %.blif : %.v
-	$(COMPILE.v) -p "synth_ice40 -top top -blif $@" $<
+	$(COMPILE.v) -p "$(SYNTH) -top top -blif $@" $<
 
 # useful for single-file builds
 %.json : %.v
-	$(COMPILE.v) -p "synth_ice40 -top top -json $@" $<
+	$(COMPILE.v) -p "$(SYNTH) -top top -json $@" $<
 
 
 # Use nextpnr-ice40 to build from a JSON file
 %.asc : %.json
-	$(NEXTPNR) --$(DEVICE) --package $(PACKAGE) --pcf $(PINMAP) --freq $(FREQ) --asc $@ --json $<
+	$(NEXTPNR) --$(DEVICE) --package $(PACKAGE) --$(PIN_FMT) $(PINMAP) --freq $(FREQ) $(NEXTPNR_OPT) --$(NEXTPNR_FMT) $@ --json $<
 
 # Use arachne-pnr to build from a BLIF file 
 %.asc : %.blif
@@ -95,13 +100,13 @@ FREQ		?= 25
 
 # make a binary config file from an ASC file
 %.bin : %.asc
-	icepack $< $@
+	$(PACK) $< $@
 
 # Run Icarus and generate a vcd file (containing waveforms from the simulation)
 %.vcd: %.vvp
 	vvp $<
 
 clean::
-	rm -f *.bin *.vvp *.vcd *.asc *.blif *.json
+	rm -f *.bin *.vvp *.vcd *.asc *.blif *.json *.rpt
 
 world:: clean all

--- a/fpga/asci/Makefile
+++ b/fpga/asci/Makefile
@@ -12,7 +12,7 @@ all:: top.bin
 
 
 top.json: $(FILES) rom.hex
-	$(COMPILE.v) -p "synth_ice40 -top top -json $@" $(FILES)
+	$(COMPILE.v) -p "$(SYNTH) -top top -json $@" $(FILES) $(COMPILE_OPT)
 
 timing: top.asc
 	icetime -tmd $(DEVICE) $^

--- a/fpga/loop/Makefile
+++ b/fpga/loop/Makefile
@@ -11,7 +11,7 @@ FILES= \
 all:: top.bin
 
 top.json: $(FILES)
-	$(COMPILE.v) -p "synth_ice40 -top top -json $@" $^
+	$(COMPILE.v) -p "$(SYNTH) -top top -json $@" $(COMPILE_OPT) $^
 
 timing: top.asc
 	icetime -tmd $(DEVICE) $^

--- a/fpga/nop/Makefile
+++ b/fpga/nop/Makefile
@@ -10,7 +10,7 @@ FILES= \
 all:: top.bin
 
 top.json: $(FILES)
-	$(COMPILE.v) -p "synth_ice40 -top top -json $@" $^
+	$(COMPILE.v) -p "$(SYNTH) -top top -json $@" $(COMPILE_OPT) $^
 
 timing: top.asc
 	icetime -tmd $(DEVICE) $^

--- a/fpga/nouveau-vdp/Makefile
+++ b/fpga/nouveau-vdp/Makefile
@@ -19,7 +19,7 @@ FILES= \
 all:: top.bin
 
 top.json: $(FILES) rom.hex
-	$(COMPILE.v) -p "synth_ice40 -top top -json $@" $(FILES)
+	$(COMPILE.v) -p "$(SYNTH) -top top -json $@" $(FILES) $(COMPILE_OPT)
 
 timing: top.asc
 	icetime -tmd $(DEVICE) $^

--- a/fpga/nouveau/Makefile
+++ b/fpga/nouveau/Makefile
@@ -13,7 +13,7 @@ all:: top.bin
 
 
 top.json: $(FILES) rom.hex
-	$(COMPILE.v) -p "synth_ice40 -top top -json $@" $(FILES)
+	$(COMPILE.v) -p "$(SYNTH) -top top -json $@" $(FILES) $(COMPILE_OPT)
 
 timing: top.asc
 	icetime -tmd $(DEVICE) $^

--- a/fpga/nouveau2/Makefile
+++ b/fpga/nouveau2/Makefile
@@ -17,7 +17,7 @@ all:: top.bin
 
 
 top.json: $(FILES) rom.hex
-	$(COMPILE.v) -p "synth_ice40 -top top -json $@" $(FILES)
+	$(COMPILE.v) -p "$(SYNTH) -top top -json $@" $(FILES) $(COMPILE_OPT)
 
 timing: top.asc
 	icetime -tmd $(DEVICE) $^

--- a/fpga/nouveau3/Makefile
+++ b/fpga/nouveau3/Makefile
@@ -17,7 +17,7 @@ all:: top.bin
 
 
 top.json: $(FILES) rom.hex
-	$(COMPILE.v) -p "synth_ice40 -top top -json $@" $(FILES)
+	$(COMPILE.v) -p "$(SYNTH) -top top -json $@" $(FILES) $(COMPILE_OPT)
 
 timing: top.asc
 	icetime -tmd $(DEVICE) $^

--- a/fpga/prog/Makefile
+++ b/fpga/prog/Makefile
@@ -12,7 +12,7 @@ all:: top.bin
 
 
 top.json: $(FILES) rom.hex
-	$(COMPILE.v) -p "synth_ice40 -top top -json $@" $(FILES)
+	$(COMPILE.v) -p "$(SYNTH) -top top -json $@" $(FILES) $(COMPILE_OPT)
 
 timing: top.asc
 	icetime -tmd $(DEVICE) $^

--- a/fpga/sram/Makefile
+++ b/fpga/sram/Makefile
@@ -12,7 +12,7 @@ all:: top.bin
 
 
 top.json: $(FILES) rom.hex
-	$(COMPILE.v) -p "synth_ice40 -top top -json $@" $(FILES)
+	$(COMPILE.v) -p "$(SYNTH) -top top -json $@" $(FILES) $(COMPILE_OPT)
 
 timing: top.asc
 	icetime -tmd $(DEVICE) $^

--- a/fpga/vdp/Makefile
+++ b/fpga/vdp/Makefile
@@ -28,7 +28,7 @@ FREQ=$(PX_CLK)
 all:: top.bin
 
 top.json: $(FILES) $(DEPS)
-	$(COMPILE.v) -p "synth_ice40 -top top -json $@" $(FILES)
+	$(COMPILE.v) -p "$(SYNTH) -top top -json $@" $(FILES) $(COMPILE_OPT)
 
 timing: top.asc
 	icetime -tmd $(DEVICE) $^


### PR DESCRIPTION
These changes will enable the use of the repository for other FPGA families supported by Yosys and nextpnr tools. 

This change does not incorporate PLL changes needed for other tools - a good solution for this that does not change the auto PLL build has not been found so far.

The COMPILE_OPT variable is present to allow use of optional shell commands such as report generation if needed.

the NEXTPNR_OPT variable allows additional nextpnr options such as `--randomize-seed` in a Make.local or other such file.