### PR TITLE
Change Makefile so that if COMPILE_OPT is defined to create a file, t…

### DIFF
--- a/fpga/loop/Makefile
+++ b/fpga/loop/Makefile
@@ -11,7 +11,7 @@ FILES= \
 all:: top.bin
 
 top.json: $(FILES)
-	$(COMPILE.v) -p "$(SYNTH) -top top -json $@" $(COMPILE_OPT) $^
+	$(COMPILE.v) -p "$(SYNTH) -top top -json $@" $(FILES) $(COMPILE_OPT)
 
 timing: top.asc
 	icetime -tmd $(DEVICE) $^

--- a/fpga/nop/Makefile
+++ b/fpga/nop/Makefile
@@ -10,7 +10,7 @@ FILES= \
 all:: top.bin
 
 top.json: $(FILES)
-	$(COMPILE.v) -p "$(SYNTH) -top top -json $@" $(COMPILE_OPT) $^
+	$(COMPILE.v) -p "$(SYNTH) -top top -json $@" $(FILES) $(COMPILE_OPT)
 
 timing: top.asc
 	icetime -tmd $(DEVICE) $^


### PR DESCRIPTION
When building the `nop` and `loop` projects yosys fails without printing an error and then nextpnr fails. This happens when Make.local contains `COMPILE_OPT += | tee $(basename $@)_yosys.rpt` which causes top.v to be overwritten with the yosys report file.

```
Generating RTLIL representation for module `\SB_MAC16'.
Generating RTLIL representation for module `\ICESTORM_RAM'.
Successfully finished Verilog frontend.

1.2. Executing HIERARCHY pass (managing design hierarchy).
nextpnr-ice40 --hx8k --package tq144:4k --pcf ../pinmap-2057.pcf --freq 25 --log top_nextpnr.rpt --asc top.asc --json top.json
ERROR: Failed to open JSON file 'top.json'.
0 warnings, 1 error
make: *** [../Make.rules:87: top.asc] Error 255
```

This PR is to fix the issue by using the Makefile compile line that is used in all the other builds.